### PR TITLE
Add response after creating location

### DIFF
--- a/server/routes/api/locations.js
+++ b/server/routes/api/locations.js
@@ -40,6 +40,7 @@ router.post("/", multerUploads, async (req, res) => {
           photo: image,
           likeCount: 0,
         });
+        res.status(201).send();
       })
       .catch((err) =>
         res.status(400).json({


### PR DESCRIPTION
## Summary
- send `201 Created` response after inserting a new location

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68815fea2e3c832e86354117254e7802